### PR TITLE
[SBCQ-20] Auth expiry modal

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,7 @@
 import type { Metadata } from "next"
 import "./styles/globals.css"
 import localFont from "next/font/local"
-import { Suspense } from "react"
-import { AuthInitializer } from "@/components/auth/AuthInitializer"
-import { LogoutHandler } from "@/components/auth/LogoutHandler"
+import { AuthProvider } from "@/components/auth/AuthProvider"
 
 const BCSans = localFont({
   src: [
@@ -44,11 +42,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${BCSans.variable} font-sans`}>
-        <AuthInitializer />
-        <Suspense fallback={null}>
-          {/* Suspense is required because LogoutHandler uses useSearchParams */}
-          <LogoutHandler />
-        </Suspense>
+        <AuthProvider />
         {children}
       </body>
     </html>

--- a/src/components/auth/AuthExpiryModal/AuthExpiryModal.tsx
+++ b/src/components/auth/AuthExpiryModal/AuthExpiryModal.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import {
+  DialogActions,
+  DialogBody,
+  DialogHeader,
+  DialogTitle,
+  Modal,
+} from "@/components/common/dialog"
+import { LoginButton } from "../LoginButton"
+import LogoutButton from "../LogoutButton"
+import { useAuthExpiry } from "./useAuthExpiry"
+
+/**
+ * Modal that appears when the user's session is about to expire.
+ * Displays a 2-minute countdown and allows the user to login to extend their session.
+ */
+export const AuthExpiryModal = () => {
+  const { showExpiryWarning, timeRemaining, formatTime } = useAuthExpiry()
+
+  return (
+    <Modal
+      open={showExpiryWarning}
+      onClose={() => {
+        /* No-op close handler */
+      }}
+      disableEscapeKeyClose={true}
+    >
+      <DialogHeader>
+        <DialogTitle>Session Expiring Soon</DialogTitle>
+      </DialogHeader>
+
+      <DialogBody>
+        <div className="space-y-4">
+          <p>Your session is about to expire. You will be automatically logged out in:</p>
+
+          <div className="text-center">
+            <div className="text-3xl font-bold text-gold-800 mb-2">{formatTime(timeRemaining)}</div>
+            <p className="text-sm text-gray-600">Click "Stay Logged In" to extend your session</p>
+          </div>
+        </div>
+      </DialogBody>
+
+      <DialogActions>
+        <LogoutButton variant="tertiary" />
+        <LoginButton text="Stay Logged In" />
+      </DialogActions>
+    </Modal>
+  )
+}
+
+export default AuthExpiryModal

--- a/src/components/auth/AuthExpiryModal/index.ts
+++ b/src/components/auth/AuthExpiryModal/index.ts
@@ -1,0 +1,2 @@
+export * from "./AuthExpiryModal"
+export { default } from "./AuthExpiryModal"

--- a/src/components/auth/AuthExpiryModal/useAuthExpiry.test.ts
+++ b/src/components/auth/AuthExpiryModal/useAuthExpiry.test.ts
@@ -1,0 +1,371 @@
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useAuthStore } from "@/stores/auth/store"
+import { useAuthExpiry } from "./useAuthExpiry"
+
+// Mock the auth store
+vi.mock("@/stores/auth/store", () => ({
+  useAuthStore: vi.fn(),
+}))
+
+const mockedUseAuthStore = vi.mocked(useAuthStore)
+
+describe("useAuthExpiry", () => {
+  // Mock timers to control setInterval behavior
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe("initial state", () => {
+    it("should initialize with correct default values when showExpiryWarning is false", () => {
+      mockedUseAuthStore.mockReturnValue(false)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.showExpiryWarning).toBe(false)
+      expect(result.current.timeRemaining).toBe(120) // 2 minutes
+      expect(typeof result.current.formatTime).toBe("function")
+    })
+
+    it("should initialize with correct default values when showExpiryWarning is true", () => {
+      mockedUseAuthStore.mockReturnValue(true)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.showExpiryWarning).toBe(true)
+      expect(result.current.timeRemaining).toBe(120) // 2 minutes
+      expect(typeof result.current.formatTime).toBe("function")
+    })
+
+    it("should return all expected properties", () => {
+      mockedUseAuthStore.mockReturnValue(false)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current).toHaveProperty("showExpiryWarning")
+      expect(result.current).toHaveProperty("timeRemaining")
+      expect(result.current).toHaveProperty("formatTime")
+    })
+  })
+
+  describe("formatTime function", () => {
+    beforeEach(() => {
+      mockedUseAuthStore.mockReturnValue(false)
+    })
+
+    it("should format seconds correctly for various times", () => {
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.formatTime(0)).toBe("0:00")
+      expect(result.current.formatTime(5)).toBe("0:05")
+      expect(result.current.formatTime(59)).toBe("0:59")
+      expect(result.current.formatTime(60)).toBe("1:00")
+      expect(result.current.formatTime(65)).toBe("1:05")
+      expect(result.current.formatTime(120)).toBe("2:00")
+      expect(result.current.formatTime(125)).toBe("2:05")
+      expect(result.current.formatTime(3661)).toBe("61:01") // Over 60 minutes
+    })
+
+    it("should pad single digit seconds with zero", () => {
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.formatTime(1)).toBe("0:01")
+      expect(result.current.formatTime(9)).toBe("0:09")
+      expect(result.current.formatTime(61)).toBe("1:01")
+      expect(result.current.formatTime(69)).toBe("1:09")
+    })
+
+    it("should handle edge cases", () => {
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.formatTime(-1)).toBe("-1:-1") // Negative numbers
+      expect(result.current.formatTime(3600)).toBe("60:00") // Exactly 1 hour
+    })
+  })
+
+  describe("countdown timer behavior", () => {
+    it("should not start timer when showExpiryWarning is false", () => {
+      mockedUseAuthStore.mockReturnValue(false)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      // Advance time and check that countdown doesn't change
+      act(() => {
+        vi.advanceTimersByTime(5000) // 5 seconds
+      })
+
+      expect(result.current.timeRemaining).toBe(120)
+    })
+
+    it("should start countdown when showExpiryWarning becomes true", () => {
+      // Start with false
+      const mockStore = vi.fn().mockReturnValue(false)
+      mockedUseAuthStore.mockImplementation(mockStore)
+
+      const { result, rerender } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.timeRemaining).toBe(120)
+
+      // Change to true
+      mockStore.mockReturnValue(true)
+      rerender()
+
+      // Advance timer by 5 seconds
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(result.current.timeRemaining).toBe(115)
+    })
+
+    it("should decrement timeRemaining every second when warning is active", () => {
+      mockedUseAuthStore.mockReturnValue(true)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.timeRemaining).toBe(120)
+
+      // Advance by 1 second
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(result.current.timeRemaining).toBe(119)
+
+      // Advance by another 5 seconds
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(result.current.timeRemaining).toBe(114)
+
+      // Advance by 10 more seconds
+      act(() => {
+        vi.advanceTimersByTime(10000)
+      })
+      expect(result.current.timeRemaining).toBe(104)
+    })
+
+    it("should stop countdown when timeRemaining reaches 0", () => {
+      mockedUseAuthStore.mockReturnValue(true)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      // Fast-forward to near the end
+      act(() => {
+        vi.advanceTimersByTime(119000) // 119 seconds
+      })
+      expect(result.current.timeRemaining).toBe(1)
+
+      // Advance one more second
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(result.current.timeRemaining).toBe(0)
+
+      // Advance more time - should stay at 0
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(result.current.timeRemaining).toBe(0)
+    })
+
+    it("should stop countdown when showExpiryWarning becomes false", () => {
+      // Start with true
+      const mockStore = vi.fn().mockReturnValue(true)
+      mockedUseAuthStore.mockImplementation(mockStore)
+
+      const { result, rerender } = renderHook(() => useAuthExpiry())
+
+      // Let some time pass
+      act(() => {
+        vi.advanceTimersByTime(10000) // 10 seconds
+      })
+      expect(result.current.timeRemaining).toBe(110)
+
+      // Change to false
+      mockStore.mockReturnValue(false)
+      rerender()
+
+      // Advance more time - should not change
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+      expect(result.current.timeRemaining).toBe(110)
+    })
+  })
+
+  describe("countdown reset behavior", () => {
+    it("should reset timeRemaining to 120 when showExpiryWarning changes from false to true", () => {
+      // Start with false
+      const mockStore = vi.fn().mockReturnValue(false)
+      mockedUseAuthStore.mockImplementation(mockStore)
+
+      const { result, rerender } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.timeRemaining).toBe(120)
+
+      // Change to true - should reset and start countdown
+      mockStore.mockReturnValue(true)
+      rerender()
+
+      expect(result.current.timeRemaining).toBe(120)
+
+      // Let time pass
+      act(() => {
+        vi.advanceTimersByTime(30000) // 30 seconds
+      })
+      expect(result.current.timeRemaining).toBe(90)
+
+      // Change back to false then true again - should reset
+      mockStore.mockReturnValue(false)
+      rerender()
+
+      mockStore.mockReturnValue(true)
+      rerender()
+
+      expect(result.current.timeRemaining).toBe(120)
+    })
+
+    it("should not reset timeRemaining when showExpiryWarning stays true", () => {
+      mockedUseAuthStore.mockReturnValue(true)
+
+      const { result, rerender } = renderHook(() => useAuthExpiry())
+
+      // Let time pass
+      act(() => {
+        vi.advanceTimersByTime(45000) // 45 seconds
+      })
+      expect(result.current.timeRemaining).toBe(75)
+
+      // Rerender but keep showExpiryWarning true - should not reset
+      rerender()
+      expect(result.current.timeRemaining).toBe(75)
+    })
+  })
+
+  describe("timer cleanup", () => {
+    it("should clear timer when component unmounts", () => {
+      mockedUseAuthStore.mockReturnValue(true)
+
+      const clearIntervalSpy = vi.spyOn(global, "clearInterval")
+
+      const { result, unmount } = renderHook(() => useAuthExpiry())
+
+      // Let time pass to start the timer
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+      expect(result.current.timeRemaining).toBe(119)
+
+      // Unmount component
+      unmount()
+
+      // Verify clearInterval was called
+      expect(clearIntervalSpy).toHaveBeenCalled()
+
+      clearIntervalSpy.mockRestore()
+    })
+
+    it("should clear previous timer when showExpiryWarning changes", () => {
+      const mockStore = vi.fn().mockReturnValue(true)
+      mockedUseAuthStore.mockImplementation(mockStore)
+
+      const clearIntervalSpy = vi.spyOn(global, "clearInterval")
+
+      const { rerender } = renderHook(() => useAuthExpiry())
+
+      // Change warning state to trigger timer cleanup and restart
+      mockStore.mockReturnValue(false)
+      rerender()
+
+      mockStore.mockReturnValue(true)
+      rerender()
+
+      // Should have called clearInterval when stopping and restarting timer
+      expect(clearIntervalSpy).toHaveBeenCalled()
+
+      clearIntervalSpy.mockRestore()
+    })
+  })
+
+  describe("edge cases", () => {
+    it("should handle rapid state changes", () => {
+      const mockStore = vi.fn().mockReturnValue(false)
+      mockedUseAuthStore.mockImplementation(mockStore)
+
+      const { result, rerender } = renderHook(() => useAuthExpiry())
+
+      // Rapid state changes
+      act(() => {
+        mockStore.mockReturnValue(true)
+        rerender()
+        vi.advanceTimersByTime(1000)
+
+        mockStore.mockReturnValue(false)
+        rerender()
+
+        mockStore.mockReturnValue(true)
+        rerender()
+      })
+
+      // Should reset to 120 after the final true state
+      expect(result.current.timeRemaining).toBe(120)
+    })
+
+    it("should work correctly when timeRemaining goes negative", () => {
+      mockedUseAuthStore.mockReturnValue(true)
+
+      const { result } = renderHook(() => useAuthExpiry())
+
+      // Manually set timeRemaining to 1 and let it decrement
+      act(() => {
+        vi.advanceTimersByTime(120000) // 120 seconds - should reach 0
+      })
+
+      expect(result.current.timeRemaining).toBe(0)
+
+      // Timer should stop, so advancing more time shouldn't change it
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(result.current.timeRemaining).toBe(0)
+    })
+  })
+
+  describe("auth store integration", () => {
+    it("should read showExpiryWarning from auth store", () => {
+      const mockSelector = vi.fn()
+      mockedUseAuthStore.mockImplementation(mockSelector)
+
+      renderHook(() => useAuthExpiry())
+
+      expect(mockSelector).toHaveBeenCalledWith(expect.any(Function))
+
+      // Test the selector function
+      const selectorFn = mockSelector.mock.calls[0][0]
+      const mockStoreState = { showExpiryWarning: true, other: "value" }
+
+      expect(selectorFn(mockStoreState)).toBe(true)
+    })
+
+    it("should update when auth store showExpiryWarning changes", () => {
+      const mockStore = vi.fn().mockReturnValue(false)
+      mockedUseAuthStore.mockImplementation(mockStore)
+
+      const { result, rerender } = renderHook(() => useAuthExpiry())
+
+      expect(result.current.showExpiryWarning).toBe(false)
+
+      // Change store value
+      mockStore.mockReturnValue(true)
+      rerender()
+
+      expect(result.current.showExpiryWarning).toBe(true)
+    })
+  })
+})

--- a/src/components/auth/AuthExpiryModal/useAuthExpiry.ts
+++ b/src/components/auth/AuthExpiryModal/useAuthExpiry.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react"
+import { useAuthStore } from "@/stores/auth/store"
+
+const EXPIRY_WARNING_DURATION_SECONDS = 120 // 2 minutes
+
+export type UseAuthExpiryReturn = {
+  showExpiryWarning: boolean
+  timeRemaining: number
+  formatTime: (seconds: number) => string
+}
+
+/**
+ * Hook for managing authentication expiry warning state and countdown timer.
+ *
+ * To test manually, temporarily set `TEN_HOURS_MS = 3 * 60 * 1000` in `src/stores/auth/store.ts`.
+ * This will open the expiry modal after 1 minutes, leaving the modal open for another 2 minutes.
+ *
+ * @returns Object containing expiry warning state, time remaining, and time formatting function
+ */
+export const useAuthExpiry = (): UseAuthExpiryReturn => {
+  const showExpiryWarning = useAuthStore((s) => s.showExpiryWarning)
+  const [timeRemaining, setTimeRemaining] = useState(EXPIRY_WARNING_DURATION_SECONDS)
+
+  // Reset countdown when modal opens
+  useEffect(() => {
+    if (showExpiryWarning) {
+      setTimeRemaining(EXPIRY_WARNING_DURATION_SECONDS)
+    }
+  }, [showExpiryWarning])
+
+  // Countdown timer
+  useEffect(() => {
+    if (!showExpiryWarning || timeRemaining <= 0) return
+
+    const timer = setInterval(() => {
+      setTimeRemaining((prev) => prev - 1)
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [showExpiryWarning, timeRemaining])
+
+  // Format time as MM:SS
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`
+  }
+
+  return {
+    showExpiryWarning,
+    timeRemaining,
+    formatTime,
+  }
+}

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from "react"
+import AuthExpiryModal from "./AuthExpiryModal"
+import AuthInitializer from "./AuthInitializer"
+import LogoutHandler from "./LogoutHandler"
+
+/**
+ * AuthProvider component that initializes authentication and handles session expiration.
+ */
+export const AuthProvider = () => {
+  return (
+    <>
+      <AuthInitializer />
+      <AuthExpiryModal />
+      <Suspense fallback={null}>
+        {/* Suspense is required because LogoutHandler uses useSearchParams */}
+        <LogoutHandler />
+      </Suspense>
+    </>
+  )
+}
+
+export default AuthProvider

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -5,10 +5,20 @@ import { useAuthStore } from "@/stores/auth/store"
 import { openPopup } from "@/utils/auth/popup/openPopup"
 import { pollPopupLogin } from "@/utils/auth/popup/pollPopupLogin"
 
+export type LoginButtonProps = {
+  text?: string
+  variant?: "primary" | "secondary" | "tertiary"
+}
+
 /**
  * Login button component that opens a popup for user authentication.
+ *
+ * @param {LoginButtonProps} props - Props for the login button
+ *
+ * @property {string} [text="Login"] - The button text
+ * @property {string} [variant="primary"] - The button variant
  */
-export const LoginButton = () => {
+export const LoginButton = ({ text = "Login", variant = "primary" }: LoginButtonProps) => {
   const loginFromTokens = useAuthStore((s) => s.loginFromTokens)
 
   const onClick = useCallback(async () => {
@@ -30,8 +40,8 @@ export const LoginButton = () => {
   }, [loginFromTokens])
 
   return (
-    <button type="button" className="primary" onClick={onClick}>
-      Login
+    <button type="button" className={`${variant}`} onClick={onClick}>
+      {text}
     </button>
   )
 }

--- a/src/components/auth/LogoutButton.tsx
+++ b/src/components/auth/LogoutButton.tsx
@@ -2,12 +2,22 @@
 
 import { useCallback } from "react"
 
+export type LogoutButtonProps = {
+  text?: string
+  variant?: "primary" | "secondary" | "tertiary"
+}
+
 /**
  * Logout button which navigates the browser to the logout API.
  * The API will redirect to the SSO logout page and then back to the
  * provided post-logout redirect (we attach `?post_logout=true`).
+ *
+ * @param {LogoutButtonProps} props - Props for the logout button
+ *
+ * @property {string} [text="Logout"] - The button text
+ * @property {string} [variant="primary"] - The button variant
  */
-export const LogoutButton = () => {
+export const LogoutButton = ({ text = "Logout", variant = "primary" }: LogoutButtonProps) => {
   const onClick = useCallback(() => {
     const redirectUri = `${window.location.origin}/?post_logout=true`
     // Force a full navigation so cookies are sent to /api/auth/logout
@@ -15,8 +25,8 @@ export const LogoutButton = () => {
   }, [])
 
   return (
-    <button type="button" className="primary" onClick={onClick}>
-      Logout
+    <button type="button" className={`${variant}`} onClick={onClick}>
+      {text}
     </button>
   )
 }

--- a/src/stores/auth/store.ts
+++ b/src/stores/auth/store.ts
@@ -67,7 +67,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       getSession: () => get().session,
       onRefresh: () => get().refresh(),
       onShowWarning: () => get().setShowExpiryWarning(true),
-      onHardLogout: () => get().logout("expired"),
+      onHardLogout: () => get().logout(),
     })
   },
 

--- a/src/stores/auth/timers.ts
+++ b/src/stores/auth/timers.ts
@@ -39,8 +39,8 @@ export const scheduleAuthTimers = ({
     }
   }, refreshIn)
 
-  // Session warning at T-2m, hard logout at T
-  const warnIn = Math.max(1_000, session.sessionEndsAt - now - 120_000)
+  // Session warning at T-2m+2s, hard logout at T
+  const warnIn = Math.max(1_000, session.sessionEndsAt - now - 122_000)
   const logoutIn = Math.max(1_000, session.sessionEndsAt - now)
 
   sessionWarnTO = setTimeout(() => onShowWarning(), warnIn)


### PR DESCRIPTION
## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->
[SBCQ-20](https://citz-imb.atlassian.net/browse/SBCQ-20)

<!-- PROVIDE BELOW an explanation of your changes and any supporting images -->
Expiry modal pops up 2 minutes before auth session ends to let the user decide to stay logged in or logout.

## 🧪 Testing
To test manually, temporarily set `TEN_HOURS_MS = 3 * 60 * 1000` in `src/stores/auth/store.ts`.  
This will open the expiry modal after 1 minutes, leaving the modal open for another 2 minutes.

<!--
PROVIDE BELOW information on how to manually test all changes.
Include tests that you have completed and any additional files/ documents required to test. -->

## 🔰 Checklist

- [x] I have read and agree with the following checklist.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
